### PR TITLE
Fix delta computation between current and incident time

### DIFF
--- a/src/pdh/transformations.py
+++ b/src/pdh/transformations.py
@@ -34,7 +34,7 @@ class Transformation(object):
     def extract_date(item_name: str, format: str = "%Y-%m-%dT%H:%M:%SZ"):
         def extract(i: dict) -> str:
             d = datetime.strptime(i[item_name], format)
-            duration = datetime.now() - d
+            duration = datetime.utcnow() - d
             data = {}
             data["d"], remaining = divmod(duration.total_seconds(), 86_400)
             data["h"], remaining = divmod(remaining, 3_600)


### PR DESCRIPTION
As per title, `now` method return a datetime in local time, while the time returned by PD api is UTC time.
To keep it simple, I [chose](https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow) `utcnow` method, instead of `now` with `tz` arg, because it produce a naive (tz unaware) datetime, from which only another naive datetime (the one produced by `strptime` method) can be subtracted.