### PR TITLE
fix: removed `fields` redefinition in watch mode loop

### DIFF
--- a/src/pdh/main.py
+++ b/src/pdh/main.py
@@ -294,11 +294,6 @@ def inc_list(ctx, everything, user, new, ack, output, snooze, resolve, high, low
         if excluded_service_re:
             incs = Filter.do(incs, transformations={"service": Transformation.extract_from_dict("service","summary")}, filters=[Filter.not_regexp("service", excluded_service_re)], preserve=True)
 
-        if type(fields) is str:
-            fields = fields.lower().strip().split(",")
-        else:
-            fields = ["id", "assignee", "title", "status", "created_at", "last_status_change_at", "url"]
-
         if alerts:
             for i in incs:
                 i["alerts"] = pd.alerts(i["id"])


### PR DESCRIPTION
## Changes:

* `fields` var is already set outside watch mode loop (either parsed from option or statically set). This can't be done more then once, since `fields` var will hold the parsed list and won't ever be recognized again as the str typed option. Furthermore It doesn't really need to be re-evalueted at every incident fetch occurence, in the loop.