### PR TITLE
Adding flag to sort incident list by field name (with reverse option and multiple fields support)

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,12 @@ Invalid sort field: unkn
 Available fields: id, assignee, title, status, created_at, last_status_change_at, url
 ```
 
+You can always sort by multiple fields using comma as separator:
+
+```bash
+pdh inc ls --sort assignee,status
+```
+
 ### Auto ACK incoming incidents
 
 Watch for new incidents every 10s and automatically set them to `Acknowledged`

--- a/README.md
+++ b/README.md
@@ -99,6 +99,20 @@ Any other incident currently outstanding:
 pdh inc ls -e
 ```
 
+### Sorting incident by field
+
+```bash
+pdh inc ls --sort assignee --reverse
+```
+
+In case the field is not found the cli will notice you and print the list of available fields
+
+```bash
+ pdh inc ls -e --sort unkn --reverse
+Invalid sort field: unkn
+Available fields: id, assignee, title, status, created_at, last_status_change_at, url
+```
+
 ### Auto ACK incoming incidents
 
 Watch for new incidents every 10s and automatically set them to `Acknowledged`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ ignore = [
 
 [tool.poetry]
 name = "pdh"
-version = "0.4.3"
+version = "0.4.4"
 description = "Pagerduty CLI for Humans"
 authors = ["Manuel Bovo <manuel.bovo@gmail.com>"]
 license = "GPL-3.0-or-later"

--- a/rules/examples.py
+++ b/rules/examples.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 #
 # This file is part of the pdh (https://github.com/mbovo/pdh).
-# Copyright (c) 2020-2023 Manuel Bovo.
+# Copyright (c) 2020-2024 Manuel Bovo.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/pdh/__init__.py
+++ b/src/pdh/__init__.py
@@ -1,6 +1,6 @@
 #
 # This file is part of the pdh (https://github.com/mbovo/pdh).
-# Copyright (c) 2020-2023 Manuel Bovo.
+# Copyright (c) 2020-2024 Manuel Bovo.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/pdh/config.py
+++ b/src/pdh/config.py
@@ -1,6 +1,6 @@
 #
 # This file is part of the pdh (https://github.com/mbovo/pdh).
-# Copyright (c) 2020-2023 Manuel Bovo.
+# Copyright (c) 2020-2024 Manuel Bovo.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/pdh/core.py
+++ b/src/pdh/core.py
@@ -1,6 +1,6 @@
 #
 # This file is part of the pdh (https://github.com/mbovo/pdh).
-# Copyright (c) 2020-2023 Manuel Bovo.
+# Copyright (c) 2020-2024 Manuel Bovo.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/pdh/filters.py
+++ b/src/pdh/filters.py
@@ -1,6 +1,6 @@
 #
 # This file is part of the pdh (https://github.com/mbovo/pdh).
-# Copyright (c) 2020-2023 Manuel Bovo.
+# Copyright (c) 2020-2024 Manuel Bovo.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -132,7 +132,7 @@ class Filter(object):
 
         return f
 
-    def do(objects: list, transformations: dict = None, filters: list = [], preserve : bool = False) -> list:
+    def do(objects: list, transformations: dict|None = None, filters: list = [], preserve : bool = False) -> list:
         """Given a list of objects, apply every transformations and filters on it, return the new filtered list
         Transformations is a dict of "key": func(item) where key is the destination key and func(item) the
                         function to used to extract values from the original list (see Transformation class)

--- a/src/pdh/main.py
+++ b/src/pdh/main.py
@@ -241,7 +241,9 @@ def apply(ctx, incident, path, output, script):
 @click.option("--alert-fields", "alert_fields", required=False, help="Show these alert fields only, comma separated", default=None)
 @click.option("-S","--service-re", "service_re", required=False, help="Show only incidents for this service (regexp)", default=None)
 @click.option("--excluded-service-re", "excluded_service_re", required=False, help="Exclude incident of these services (regexp)", default=None)
-def inc_list(ctx, everything, user, new, ack, output, snooze, resolve, high, low, watch, timeout, regexp, apply, rules_path, fields, alerts, alert_fields, service_re, excluded_service_re):
+@click.option("--sort", "sort_by", required=False, help="Sort by field name", default=None)
+@click.option("--reverse", "reverse_sort", required=False, help="Reverse the sort", is_flag=True, default=False)
+def inc_list(ctx, everything, user, new, ack, output, snooze, resolve, high, low, watch, timeout, regexp, apply, rules_path, fields, alerts, alert_fields, service_re, excluded_service_re, sort_by, reverse_sort):
 
     # Prepare defaults
     status = [STATUS_TRIGGERED]
@@ -328,6 +330,14 @@ def inc_list(ctx, everything, user, new, ack, output, snooze, resolve, high, low
             for f in fields:
                 s += f"{i[f]}\t"
             print(s)
+
+        if sort_by :
+            try:
+                filtered = sorted(filtered, key=lambda x: x[sort_by], reverse=reverse_sort)
+            except KeyError:
+                print(f"[red]Invalid sort field: {sort_by}[/red]")
+                print(f"[yellow]Available fields: {', '.join(fields)}[/yellow]")
+                sys.exit(-2)
 
         print_items(filtered, output, plain_print_f=plain_print_f)
 

--- a/src/pdh/main.py
+++ b/src/pdh/main.py
@@ -331,9 +331,15 @@ def inc_list(ctx, everything, user, new, ack, output, snooze, resolve, high, low
                 s += f"{i[f]}\t"
             print(s)
 
-        if sort_by :
+
+        if sort_by:
             try:
-                filtered = sorted(filtered, key=lambda x: x[sort_by], reverse=reverse_sort)
+                sort_fields: str|list[str] = sort_by.split(",")  if ',' in sort_by else sort_by
+
+                if isinstance(sort_fields, list) and len(sort_fields) > 1:
+                    filtered = sorted(filtered, key=lambda x: [x[k] for k in sort_fields], reverse=reverse_sort)
+                else:
+                    filtered = sorted(filtered, key=lambda x: x[sort_fields], reverse=reverse_sort)
             except KeyError:
                 print(f"[red]Invalid sort field: {sort_by}[/red]")
                 print(f"[yellow]Available fields: {', '.join(fields)}[/yellow]")

--- a/src/pdh/main.py
+++ b/src/pdh/main.py
@@ -1,6 +1,6 @@
 #
 # This file is part of the pdh (https://github.com/mbovo/pdh).
-# Copyright (c) 2020-2023 Manuel Bovo.
+# Copyright (c) 2020-2024 Manuel Bovo.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/pdh/output.py
+++ b/src/pdh/output.py
@@ -1,6 +1,6 @@
 #
 # This file is part of the pdh (https://github.com/mbovo/pdh).
-# Copyright (c) 2020-2023 Manuel Bovo.
+# Copyright (c) 2020-2024 Manuel Bovo.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/pdh/pd.py
+++ b/src/pdh/pd.py
@@ -1,6 +1,6 @@
 #
 # This file is part of the pdh (https://github.com/mbovo/pdh).
-# Copyright (c) 2020-2023 Manuel Bovo.
+# Copyright (c) 2020-2024 Manuel Bovo.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/pdh/rules.py
+++ b/src/pdh/rules.py
@@ -1,6 +1,6 @@
 #
 # This file is part of the pdh (https://github.com/mbovo/pdh).
-# Copyright (c) 2020-2023 Manuel Bovo.
+# Copyright (c) 2020-2024 Manuel Bovo.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/pdh/transformations.py
+++ b/src/pdh/transformations.py
@@ -1,6 +1,6 @@
 #
 # This file is part of the pdh (https://github.com/mbovo/pdh).
-# Copyright (c) 2020-2023 Manuel Bovo.
+# Copyright (c) 2020-2024 Manuel Bovo.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,6 @@
 #
 # This file is part of the pdh (https://github.com/mbovo/pdh).
-# Copyright (c) 2020-2023 Manuel Bovo.
+# Copyright (c) 2020-2024 Manuel Bovo.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,7 +1,7 @@
 
 #
 # This file is part of the pdh (https://github.com/mbovo/pdh).
-# Copyright (c) 2020-2023 Manuel Bovo.
+# Copyright (c) 2020-2024 Manuel Bovo.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,6 +1,6 @@
 #
 # This file is part of the pdh (https://github.com/mbovo/pdh).
-# Copyright (c) 2020-2023 Manuel Bovo.
+# Copyright (c) 2020-2024 Manuel Bovo.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,6 @@
 #
 # This file is part of the pdh (https://github.com/mbovo/pdh).
-# Copyright (c) 2020-2023 Manuel Bovo.
+# Copyright (c) 2020-2024 Manuel Bovo.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/tests/test_pd.py
+++ b/tests/test_pd.py
@@ -1,6 +1,6 @@
 #
 # This file is part of the pdh (https://github.com/mbovo/pdh).
-# Copyright (c) 2020-2023 Manuel Bovo.
+# Copyright (c) 2020-2024 Manuel Bovo.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -1,6 +1,6 @@
 #
 # This file is part of the pdh (https://github.com/mbovo/pdh).
-# Copyright (c) 2020-2023 Manuel Bovo.
+# Copyright (c) 2020-2024 Manuel Bovo.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -1,6 +1,6 @@
 #
 # This file is part of the pdh (https://github.com/mbovo/pdh).
-# Copyright (c) 2020-2023 Manuel Bovo.
+# Copyright (c) 2020-2024 Manuel Bovo.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
As per title, this would work like:

```bash
pdh inc ls --sort assignee --reverse
```

In case the field is not found the cli will notice you and print the list of available fields

```bash
 pdh inc ls -e --sort unkn --reverse                                
Invalid sort field: unkn
Available fields: id, assignee, title, status, created_at, last_status_change_at, url
```
